### PR TITLE
Tweak the selection criteria so that it only credits auto-renewing subs

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -23,7 +23,7 @@ scalacOptions ++= Seq(
   "-Xfuture"
 )
 
-lazy val root = (project in file(".")).enablePlugins(ScalaxbPlugin, RiffRaffArtifact, JavaAppPackaging)
+lazy val root = (project in file(".")).enablePlugins(ScalaxbPlugin, RiffRaffArtifact)
 val dispatchV = "0.11.3" // change this to appropriate dispatch version
 
 scalaxbDispatchVersion in (Compile, scalaxb) := dispatchV
@@ -33,7 +33,8 @@ scalaxbAsync in (Compile, scalaxb) := false
 topLevelDirectory in Universal := None
 packageName in Universal := normalizedName.value
 
-riffRaffPackageType := (packageZipTarball in config("universal")).value
+assemblyJarName := "zuora-crediter.jar"
+riffRaffPackageType := assembly.value
 riffRaffUploadArtifactBucket := Option("riffraff-artifact")
 riffRaffUploadManifestBucket := Option("riffraff-builds")
 riffRaffManifestProjectName := "MemSub::Membership Admin::Zuora Crediter"

--- a/build.sbt
+++ b/build.sbt
@@ -49,7 +49,7 @@ libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-lambda-java-core" % "1.1.0",
   "com.amazonaws" % "aws-java-sdk-kms" % "1.11.86",
   "net.databinder.dispatch" %% "dispatch-core" % dispatchV,
-  "io.spray" %%  "spray-json" % "1.3.3",
+  "com.typesafe.play" %% "play-json" % "2.5.12",
   "org.scalaj" %% "scalaj-http" % "2.3.0",
   "com.github.melrief" %% "purecsv" % "0.0.9",
   "org.scalatest" %% "scalatest" % "3.0.1" % "test"

--- a/build.sbt
+++ b/build.sbt
@@ -30,9 +30,6 @@ scalaxbDispatchVersion in (Compile, scalaxb) := dispatchV
 scalaxbPackageName in (Compile, scalaxb) := "com.gu.zuora.soap"
 scalaxbAsync in (Compile, scalaxb) := false
 
-topLevelDirectory in Universal := None
-packageName in Universal := normalizedName.value
-
 assemblyJarName := "zuora-crediter.jar"
 riffRaffPackageType := assembly.value
 riffRaffUploadArtifactBucket := Option("riffraff-artifact")

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -95,9 +95,9 @@ Resources:
           ZuoraApiSecretAccessKey: ""
           ZuoraApiHost: ""
       Code:
-        S3Bucket: subscriptions-dist
+        S3Bucket: zuora-crediter-dist
         S3Key:
-          !Sub subscriptions/${Stage}/zuora-crediter/zuora-crediter.jar
+          !Sub ${Stage}/zuora-crediter/zuora-crediter.jar
       Description: This Lambda finds negative invoices and converts them to be a credit on the customer's account so that the amount is deducted off their next positive bill.
       Handler: com.gu.zuora.crediter.Lambda::handleRequest
       MemorySize: 512

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -83,7 +83,7 @@ Resources:
     Properties:
       AliasName: !Sub alias/zuora-crediter-kms
       TargetKeyId: !Ref LambdaKMSKey
-      DependsOn: LambdaKMSKey
+    DependsOn: LambdaKMSKey
 
   Lambda:
     Type: AWS::Lambda::Function

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -10,8 +10,8 @@ Parameters:
     Type: String
     AllowedValues:
       - PROD
-      - UAT
-    Default: UAT
+      - CODE
+    Default: CODE
 
 Resources:
   ZuoraCrediterRole:
@@ -105,10 +105,7 @@ Resources:
       Description: This Lambda finds negative invoices and converts them to be a credit on the customer's account so that the amount is deducted off their next positive bill.
       Handler: com.gu.zuora.crediter.Lambda::handleRequest
       MemorySize: 512
-      Role:
-        Fn::GetAtt:
-        - ZuoraCrediterRole
-        - Arn
+      Role: !GetAtt ZuoraCrediterRole.Arn
       Runtime: java8
       Timeout: 60
       KmsKeyArn:

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -1,10 +1,6 @@
 AWSTemplateFormatVersion: "2010-09-09"
 Description: AWS Lambda - This Lambda finds negative invoices and converts them to be a credit on the user's account so that the amount is discounted off their next positive bill
 Parameters:
-  App:
-    Description: Application name
-    Type: String
-    Default: zuora-crediter
   Stage:
     Description: Stage name
     Type: String
@@ -40,10 +36,10 @@ Resources:
   LambdaKMSKey:
     Type: AWS::KMS::Key
     Properties:
-      Description: !Sub Used by the ${App}-${Stage} lambda to encrypt and decrypt its environment variables
+      Description: !Sub Used by the zuora-crediter-${Stage} lambda to encrypt and decrypt its environment variables
       KeyPolicy:
         Version: '2012-10-17'
-        Id: !Sub key-policy-${App}-${Stage}
+        Id: !Sub key-policy-zuora-crediter-${Stage}
         Statement:
         - Sid: Enable IAM User Permissions
           Effect: Allow
@@ -85,14 +81,14 @@ Resources:
   LambdaKMSKeyAlias:
     Type: AWS::KMS::Alias
     Properties:
-      AliasName: !Sub alias/${App}-kms
+      AliasName: !Sub alias/zuora-crediter-kms
       TargetKeyId: !Ref LambdaKMSKey
       DependsOn: LambdaKMSKey
 
   Lambda:
     Type: AWS::Lambda::Function
     Properties:
-      FunctionName: !Sub ${App}-${Stage}
+      FunctionName: !Sub zuora-crediter-${Stage}
       Environment:
         Variables:
           ZuoraApiAccessKeyId: ""
@@ -101,7 +97,7 @@ Resources:
       Code:
         S3Bucket: subscriptions-dist
         S3Key:
-          !Sub subscriptions/${Stage}/${App}/${App}.jar
+          !Sub subscriptions/${Stage}/zuora-crediter/zuora-crediter.jar
       Description: This Lambda finds negative invoices and converts them to be a credit on the customer's account so that the amount is deducted off their next positive bill.
       Handler: com.gu.zuora.crediter.Lambda::handleRequest
       MemorySize: 512

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -40,10 +40,10 @@ Resources:
   LambdaKMSKey:
     Type: AWS::KMS::Key
     Properties:
-      Description: !Sub Used by the zuora-crediter-${Stage} lambda to encrypt and decrypt its environment variables
+      Description: !Sub Used by the ${App}-${Stage} lambda to encrypt and decrypt its environment variables
       KeyPolicy:
         Version: '2012-10-17'
-        Id: !Sub key-policy-zuora-crediter-${Stage}
+        Id: !Sub key-policy-${App}-${Stage}
         Statement:
         - Sid: Enable IAM User Permissions
           Effect: Allow
@@ -82,10 +82,17 @@ Resources:
           - kms:DescribeKey
           Resource: "*"
 
+  LambdaKMSKeyAlias:
+    Type: AWS::KMS::Alias
+    Properties:
+      AliasName: !Sub alias/${App}-kms
+      TargetKeyId: !Ref LambdaKMSKey
+      DependsOn: LambdaKMSKey
+
   Lambda:
     Type: AWS::Lambda::Function
     Properties:
-      FunctionName: !Sub zuora-crediter-${Stage}
+      FunctionName: !Sub ${App}-${Stage}
       Environment:
         Variables:
           ZuoraApiAccessKeyId: ""

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -1,10 +1,6 @@
 AWSTemplateFormatVersion: "2010-09-09"
 Description: AWS Lambda - This Lambda finds negative invoices and converts them to be a credit on the user's account so that the amount is discounted off their next positive bill
 Parameters:
-  Stack:
-    Description: Stack name
-    Type: String
-    Default: subscriptions
   App:
     Description: Application name
     Type: String
@@ -16,10 +12,6 @@ Parameters:
       - PROD
       - UAT
     Default: UAT
-  RootIAMUser:
-    Description: The root IAM user's ARN
-    Type: String
-    Default: arn:aws:iam::[enter number here]:root
 
 Resources:
   ZuoraCrediterRole:
@@ -56,8 +48,7 @@ Resources:
         - Sid: Enable IAM User Permissions
           Effect: Allow
           Principal:
-            AWS:
-              !Ref RootIAMUser
+            AWS: !Sub arn:aws:iam::${AWS::AccountId}:root
           Action: kms:*
           Resource: "*"
         - Sid: Allow access for Key Administrators
@@ -103,7 +94,7 @@ Resources:
       Code:
         S3Bucket: subscriptions-dist
         S3Key:
-          !Sub ${Stack}/${Stage}/${App}/${App}.zip
+          !Sub subscriptions/${Stage}/${App}/${App}.zip
       Description: This Lambda finds negative invoices and converts them to be a credit on the customer's account so that the amount is deducted off their next positive bill.
       Handler: com.gu.zuora.crediter.Lambda::handleRequest
       MemorySize: 512

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -101,7 +101,7 @@ Resources:
       Code:
         S3Bucket: subscriptions-dist
         S3Key:
-          !Sub subscriptions/${Stage}/${App}/${App}.zip
+          !Sub subscriptions/${Stage}/${App}/${App}.jar
       Description: This Lambda finds negative invoices and converts them to be a credit on the customer's account so that the amount is deducted off their next positive bill.
       Handler: com.gu.zuora.crediter.Lambda::handleRequest
       MemorySize: 512

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -95,9 +95,9 @@ Resources:
           ZuoraApiSecretAccessKey: ""
           ZuoraApiHost: ""
       Code:
-        S3Bucket: zuora-crediter-dist
+        S3Bucket: subscriptions-dist
         S3Key:
-          !Sub ${Stage}/zuora-crediter/zuora-crediter.jar
+          !Sub subscriptions/${Stage}/zuora-crediter/zuora-crediter.jar
       Description: This Lambda finds negative invoices and converts them to be a credit on the customer's account so that the amount is deducted off their next positive bill.
       Handler: com.gu.zuora.crediter.Lambda::handleRequest
       MemorySize: 512

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,5 @@
 addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "0.9.7")
 addSbtPlugin("org.scalaxb" % "sbt-scalaxb" % "1.5.0")
-addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.1.1")
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.3")
 
 resolvers += Resolver.typesafeRepo("releases")

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -6,12 +6,7 @@ deployments:
   ZuoraCrediter:
     type: aws-lambda
     parameters:
-      fileName: zuora-crediter.zip
+      fileName: zuora-crediter.jar
       bucket: subscriptions-dist
-      functions:
-        UAT:
-          name: Zuora-Crediter-UAT
-          filename: zuora-crediter-assembly.zip
-        PROD:
-          name: Zuora-Crediter-PROD
-          filename: zuora-crediter.zip
+      functionNames:
+      - zuora-crediter-

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -7,6 +7,6 @@ deployments:
     type: aws-lambda
     parameters:
       fileName: zuora-crediter.jar
-      bucket: subscriptions-dist
+      bucket: zuora-crediter-dist
       functionNames:
       - zuora-crediter-

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -7,7 +7,7 @@ deployments:
     type: aws-lambda
     parameters:
       fileName: zuora-crediter.jar
-      bucket: zuora-crediter-dist
+      bucket: subscriptions-dist
       prefixStack: false
       functionNames:
       - zuora-crediter-

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -3,7 +3,7 @@ stacks:
 regions:
 - eu-west-1
 deployments:
-  ZuoraCrediter:
+  zuora-crediter:
     type: aws-lambda
     parameters:
       fileName: zuora-crediter.jar

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -8,5 +8,6 @@ deployments:
     parameters:
       fileName: zuora-crediter.jar
       bucket: zuora-crediter-dist
+      prefixStack: false
       functionNames:
       - zuora-crediter-

--- a/src/main/scala/com/gu/zuora/crediter/Models.scala
+++ b/src/main/scala/com/gu/zuora/crediter/Models.scala
@@ -14,7 +14,7 @@ object Models {
     val selectForZOQL: ZOQLQueryFragment =
       "SELECT Subscription.Name, Invoice.InvoiceNumber, Invoice.InvoiceDate, Invoice.Balance " +
       "FROM InvoiceItem " +
-      "WHERE Invoice.Balance < 0 and Invoice.Status = 'Posted'"
+      "WHERE Invoice.Balance < 0 and Invoice.Status = 'Posted' and Subscription.AutoRenew = 'true'"
   }
   case class NegativeInvoiceToTransfer(invoiceNumber: String, invoiceBalance: BigDecimal, subscriberId: String) {
     val transferrableBalance: BigDecimal = if (invoiceBalance < 0) invoiceBalance * -1 else BigDecimal(0)

--- a/src/main/scala/com/gu/zuora/crediter/ZuoraAPIClients.scala
+++ b/src/main/scala/com/gu/zuora/crediter/ZuoraAPIClients.scala
@@ -1,6 +1,7 @@
 package com.gu.zuora.crediter
 
 import java.lang.System.getenv
+import java.net.URI
 import java.nio.ByteBuffer
 import java.nio.charset.Charset
 
@@ -60,9 +61,15 @@ object ZuoraAPIClientsFromEnvironment extends ZuoraAPIClients with Logging {
 
     private val soapCallOptions = CallOptions(useSingleTransaction = Some(Some(false)))
 
+    private val endpoint = s"https://${if (!zuoraApiHost.startsWith("apisandbox")) "api." else ""}$zuoraApiHost/apps/services/a/83.0"
+
+    logger.info(s"Instantiating SOAP client to endpoint: $endpoint")
+
     private val service: Soap = new com.gu.zuora.soap.SoapBindings with scalaxb.Soap11Clients with scalaxb.DispatchHttpClients {
-      override def baseAddress = new java.net.URI(s"https://$zuoraApiHost/apps/services/a/83.0")
+      override def baseAddress: URI = URI.create(endpoint)
     }.service
+
+    logger.info(s"Instantiated SOAP client successfully")
 
     private val sessionHeader = {
       val loginResponse = service.login(Some(zuoraApiAccessKeyId), Some(zuoraApiSecretAccessKey))

--- a/src/main/scala/com/gu/zuora/crediter/ZuoraExportGenerator.scala
+++ b/src/main/scala/com/gu/zuora/crediter/ZuoraExportGenerator.scala
@@ -2,7 +2,7 @@ package com.gu.zuora.crediter
 
 import com.gu.zuora.crediter.Models.ExportCommand
 import com.gu.zuora.crediter.Types.{ExportId, SerialisedJson}
-import spray.json.{DefaultJsonProtocol => DJP, _}
+import play.api.libs.json.Json.parse
 
 import scala.util.Try
 
@@ -28,10 +28,6 @@ class ZuoraExportGenerator(command: ExportCommand)(implicit zuoraRestClient: Zuo
   }
 
   def extractExportId(response: SerialisedJson): Option[ExportId] = {
-    import DJP._
-
-    Try {
-      response.parseJson.asJsObject.getFields("Id").headOption.map(_.convertTo[ExportId])
-    }.toOption.flatten.filter(_.nonEmpty)
+    Try((parse(response) \ "Id").asOpt[String]).toOption.flatten.filter(_.nonEmpty)
   }
 }

--- a/src/main/scala/com/gu/zuora/crediter/holidaysuspension/GetNegativeHolidaySuspensionInvoices.scala
+++ b/src/main/scala/com/gu/zuora/crediter/holidaysuspension/GetNegativeHolidaySuspensionInvoices.scala
@@ -5,16 +5,16 @@ import java.time.format.DateTimeFormatter.ISO_DATE_TIME
 import com.gu.zuora.crediter.Models.ExportCommand
 import com.gu.zuora.crediter.Models.NegativeInvoiceFileLine.selectForZOQL
 import com.gu.zuora.crediter.Types.SerialisedJson
-import spray.json.{JsBoolean, JsObject, JsString}
+import play.api.libs.json.Json
 
 case object GetNegativeHolidaySuspensionInvoices extends ExportCommand {
 
   override val getJSON: SerialisedJson = {
-    JsObject(
-      "Format" -> JsString("csv"),
-      "Name" -> JsString(s"Negative Holiday Suspension Invoices Export - ${now.format(ISO_DATE_TIME)}"),
-      "Query" -> JsString(s"$selectForZOQL AND InvoiceItem.ChargeName = 'Holiday Credit'"),
-      "Zip" -> JsBoolean(false)
+    Json.obj(
+      "Format" -> "csv",
+      "Name" -> s"Negative Holiday Suspension Invoices Export - ${now.format(ISO_DATE_TIME)}",
+      "Query" -> s"$selectForZOQL AND InvoiceItem.ChargeName = 'Holiday Credit'",
+      "Zip" -> false
     ).toString
   }
 

--- a/src/main/scala/com/gu/zuora/crediter/holidaysuspension/Main.scala
+++ b/src/main/scala/com/gu/zuora/crediter/holidaysuspension/Main.scala
@@ -7,7 +7,7 @@ import scala.collection.JavaConverters._
 object Main {
   def main(args: Array[String]): Unit = {
     val map1 = Map("scheduleReport" -> "GetNegativeHolidaySuspensionInvoices")
-    val map2 = Map("creditInvoicesFromExport" -> "2c92c0f859d957c3015a043a46e331be")
+    val map2 = Map("creditInvoicesFromExport" -> "2c92c0f85a1174a9015a1809cb123630")
     val lambda = new Lambda
     lambda.handleRequest(map2.asJava, null)
     System.exit(0)


### PR DESCRIPTION
- Updated the selection criteria so that it only credits auto-renewing subs. 
- Updated CloudFormation config to remove the ambiguous 'Stack' name until I know for sure what it should be!
- Updated CloudFormation to give an alias to the KMS key!
- Updated the JSON library to use the Play one which we are all more familiar with and is reportedly a bit faster.
- Fixed bug with creating the URI for the SOAP client when in prod mode.

cc @jacobwinch 