### PR TITLE
Process Credit Balance Adjustments in batches of 50

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -89,11 +89,6 @@ Resources:
     Type: AWS::Lambda::Function
     Properties:
       FunctionName: !Sub zuora-crediter-${Stage}
-      Environment:
-        Variables:
-          ZuoraApiAccessKeyId: ""
-          ZuoraApiSecretAccessKey: ""
-          ZuoraApiHost: ""
       Code:
         S3Bucket: subscriptions-dist
         S3Key:

--- a/src/main/scala/com/gu/zuora/crediter/CreditTransferService.scala
+++ b/src/main/scala/com/gu/zuora/crediter/CreditTransferService.scala
@@ -67,7 +67,7 @@ class CreditTransferService(command: CreateCreditBalanceAdjustmentCommand)(impli
 
   def createCreditBalanceAdjustments(adjustmentsToMake: Seq[CreditBalanceAdjustment]): CreditBalanceAdjustmentIDs = {
     val soapClient = zuoraClients.zuoraSoapClient
-    val batches = adjustmentsToMake.grouped(soapClient.maxNumberOfCreateObjects).toSeq
+    val batches = adjustmentsToMake.grouped(soapClient.maxNumberOfCreateObjects).toList // ensures eagerness
     batches.flatMap { adjustments =>
       val createResponse = soapClient.create(adjustments)
       if (createResponse.isLeft) {

--- a/src/main/scala/com/gu/zuora/crediter/CreditTransferService.scala
+++ b/src/main/scala/com/gu/zuora/crediter/CreditTransferService.scala
@@ -58,16 +58,18 @@ class CreditTransferService(command: CreateCreditBalanceAdjustmentCommand)(impli
       val adjustmentsToMake = invoicesToCredit.map(command.createCreditBalanceAdjustment)
       val createdAdjustments = createCreditBalanceAdjustments(adjustmentsToMake)
 
-      logger.info(s"Successfully created ${createdAdjustments.length} Credit Balance Adjustments with IDs: ${createdAdjustments.mkString(", ")}")
+      logger.info(s"Successfully created ${createdAdjustments.size} Credit Balance Adjustments with IDs: ${createdAdjustments.mkString(", ")}")
       createdAdjustments
     } else {
       Seq.empty
     }
   }
 
-  def createCreditBalanceAdjustments(adjustments: Seq[CreditBalanceAdjustment]): CreditBalanceAdjustmentIDs = {
-    if (adjustments.nonEmpty) {
-      val createResponse = zuoraClients.zuoraSoapClient.create(adjustments)
+  def createCreditBalanceAdjustments(adjustmentsToMake: Seq[CreditBalanceAdjustment]): CreditBalanceAdjustmentIDs = {
+    val soapClient = zuoraClients.zuoraSoapClient
+    val batches = adjustmentsToMake.grouped(soapClient.maxNumberOfCreateObjects).toSeq
+    batches.flatMap { adjustments =>
+      val createResponse = soapClient.create(adjustments)
       if (createResponse.isLeft) {
         logger.error(s"Unable to create any Credit Balance Adjustments. Reason: ${createResponse.left.get}")
       }
@@ -82,8 +84,6 @@ class CreditTransferService(command: CreateCreditBalanceAdjustmentCommand)(impli
         maybeId.foreach(id => logger.info(s"Successfully created Credit Balance Adjustment, ID: $id"))
         maybeId
       }).flatten
-    } else {
-      Seq.empty[String]
     }
   }
 

--- a/src/main/scala/com/gu/zuora/crediter/ZuoraAPIClients.scala
+++ b/src/main/scala/com/gu/zuora/crediter/ZuoraAPIClients.scala
@@ -22,6 +22,8 @@ trait ZuoraRestClient {
 }
 
 trait ZuoraSoapClient {
+  // https://knowledgecenter.zuora.com/DC_Developers/SOAP_API/E_SOAP_API_Calls/create_call
+  val maxNumberOfCreateObjects = 50
   def create(zObjects: Seq[ZObjectable]): Either[ZuoraSoapClientError, CreateResponse]
 }
 

--- a/src/test/scala/com/gu/zuora/crediter/CreditTransferServiceTest.scala
+++ b/src/test/scala/com/gu/zuora/crediter/CreditTransferServiceTest.scala
@@ -1,5 +1,7 @@
 package com.gu.zuora.crediter
 
+import java.util.concurrent.atomic.AtomicInteger
+
 import com.gu.zuora.crediter.ModelReaders._
 import com.gu.zuora.crediter.Models.{CreateCreditBalanceAdjustmentCommand, ExportFile, NegativeInvoiceFileLine, NegativeInvoiceToTransfer}
 import com.gu.zuora.crediter.TestSoapClient.{getSuccessfulCreateResponse, getUnsuccessfulCreateResponseForHeadSource}
@@ -99,14 +101,38 @@ class CreditTransferServiceTest extends FlatSpec {
       CreditBalanceAdjustment(Id = Some(Some(s"Refunding-$testSubscriberId-A"))),
       CreditBalanceAdjustment(Id = Some(Some(s"Refunding-$testSubscriberId-B")))
     )
+    val numberOfCalls = new AtomicInteger
     implicit val zuoraClients = new TestZuoraAPIClients {
-      override val zuoraSoapClient: ZuoraSoapClient = getSuccessfulCreateResponse(adjustmentsToCreate)
+      override val zuoraSoapClient: ZuoraSoapClient = getSuccessfulCreateResponse(adjustmentsToCreate, adjustmentsToCreate.length, numberOfCalls)
     }
     val service = new CreditTransferService(mockCommand)
     val created = service.createCreditBalanceAdjustments(adjustmentsToCreate)
+    assert(created.length == 2) // also forces eager evaluation of Seq
+    assert(numberOfCalls.intValue() == 1)
     assert(created == Seq(
       s"Refunding-$testSubscriberId-A",
       s"Refunding-$testSubscriberId-B"
+    ))
+  }
+
+  it should "process createCreditBalanceAdjustments in batches of 2" in {
+    val adjustmentsToCreate = Seq(
+      CreditBalanceAdjustment(Id = Some(Some(s"Refunding-$testSubscriberId-A"))),
+      CreditBalanceAdjustment(Id = Some(Some(s"Refunding-$testSubscriberId-B"))),
+      CreditBalanceAdjustment(Id = Some(Some(s"Refunding-$testSubscriberId-C")))
+    )
+    val numberOfCalls = new AtomicInteger
+    implicit val zuoraClients = new TestZuoraAPIClients {
+      override val zuoraSoapClient: ZuoraSoapClient = getSuccessfulCreateResponse(adjustmentsToCreate, 2, numberOfCalls)
+    }
+    val service = new CreditTransferService(mockCommand)
+    val created = service.createCreditBalanceAdjustments(adjustmentsToCreate)
+    assert(created.length == 3) // also forces eager evaluation of Seq
+    assert(numberOfCalls.intValue() == 2)
+    assert(created == Seq(
+      s"Refunding-$testSubscriberId-A",
+      s"Refunding-$testSubscriberId-B",
+      s"Refunding-$testSubscriberId-C"
     ))
   }
 

--- a/src/test/scala/com/gu/zuora/crediter/CreditTransferServiceTest.scala
+++ b/src/test/scala/com/gu/zuora/crediter/CreditTransferServiceTest.scala
@@ -107,8 +107,8 @@ class CreditTransferServiceTest extends FlatSpec {
     }
     val service = new CreditTransferService(mockCommand)
     val created = service.createCreditBalanceAdjustments(adjustmentsToCreate)
-    assert(created.length == 2) // also forces eager evaluation of Seq
     assert(numberOfCalls.intValue() == 1)
+    assert(created.length == 2)
     assert(created == Seq(
       s"Refunding-$testSubscriberId-A",
       s"Refunding-$testSubscriberId-B"
@@ -127,8 +127,8 @@ class CreditTransferServiceTest extends FlatSpec {
     }
     val service = new CreditTransferService(mockCommand)
     val created = service.createCreditBalanceAdjustments(adjustmentsToCreate)
-    assert(created.length == 3) // also forces eager evaluation of Seq
-    assert(numberOfCalls.intValue() == 2)
+    assert(numberOfCalls.intValue() == 2) // also tests eager evaluation
+    assert(created.length == 3)
     assert(created == Seq(
       s"Refunding-$testSubscriberId-A",
       s"Refunding-$testSubscriberId-B",

--- a/src/test/scala/com/gu/zuora/crediter/TestZuoraAPIClients.scala
+++ b/src/test/scala/com/gu/zuora/crediter/TestZuoraAPIClients.scala
@@ -11,8 +11,8 @@ class TestSoapClient extends ZuoraSoapClient {
 
 object TestSoapClient {
 
-  def getSuccessfulCreateResponse(source: Seq[Any], maxOverride: Int = 50, counter: AtomicInteger = new AtomicInteger) = new ZuoraSoapClient {
-    override val maxNumberOfCreateObjects: Int = maxOverride
+  def getSuccessfulCreateResponse(source: Seq[Any], batchSizeOverride: Int = 50, counter: AtomicInteger = new AtomicInteger) = new ZuoraSoapClient {
+    override val maxNumberOfCreateObjects: Int = batchSizeOverride
     override def create(zObjects: Seq[ZObjectable]): Either[ZuoraSoapClientError, CreateResponse] = {
       assert(if (source.size <= maxNumberOfCreateObjects) zObjects.size == source.size else zObjects.size <= maxNumberOfCreateObjects)
       counter.incrementAndGet()


### PR DESCRIPTION
- Ensured that the Credit Balance Adjustments are processed in batches of 50 as that's the limit for Create: https://knowledgecenter.zuora.com/DC_Developers/SOAP_API/E_SOAP_API_Calls/create_call
- Slight tweak to CloudFormation to not delete environment variables.

cc @jacobwinch @johnduffell @pvighi @AWare 