### PR TITLE
Renamed 'crediter' to 'creditor'

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Zuora negative invoice crediter
+# Zuora Creditor
 
 This repository contains a Scala-based code API to handle the process of downloading a report of negative invoices from Zuora and transferring their balance into an account credit.
 
@@ -11,7 +11,7 @@ The code is structured in a way that an implementing class only need to:
 - Configure how they want to generate a `CreditBalanceAdjustment` by extending the `CreateCreditBalanceAdjustmentCommand` trait which has a method which takes a single `NegativeInvoiceToTransfer` case class to start with.
 - Write your own main file or AWS Lambda function to orchestrate the stages of the process.
  
-The repository contains the implementation of a specific use case of this process, which targets negative holiday suspension invoices. It has a main method for local testing and an AWS Lambda incorporated into the build system for deploying to production. See the Home Delivery Suspension Scala trait overrides: [src/main/resources/scala/com/gu/zuora/crediter/holidaysuspension/...](https://github.com/guardian/zuora-crediter/tree/master/src/main/scala/com/gu/zuora/crediter/holidaysuspension).
+The repository contains the implementation of a specific use case of this process, which targets negative holiday suspension invoices. It has a main method for local testing and an AWS Lambda incorporated into the build system for deploying to production. See the Home Delivery Suspension Scala trait overrides: [src/main/resources/scala/com/gu/zuora/creditor/holidaysuspension/...](https://github.com/guardian/zuora-creditor/tree/master/src/main/scala/com/gu/zuora/creditor/holidaysuspension).
  
 # Usage
 
@@ -21,12 +21,6 @@ Run `sbt assembly` to generate the Home Delivery Holiday Suspension AWS Lambda j
 # Credits
 
 This project generates the sources for a synchronous SOAP client API from the Zuora83.wsdl using [http://scalaxb.org/](scalaxb.org),  wraps a lightweight HTTP client called: [https://github.com/scalaj/scalaj-http](scalaj-http) and uses [PureCSV](https://github.com/melrief/PureCSV) for reading the Zuora Export file into a case class.
-
-### Still to do:
-
-- CloudFormation for the Home Delivery Holiday Suspension AWS Lambda function.
-- Any tweaks to get [Riff-Raff](https://github.com/guardian/riff-raff) working to deploy the above Lambda function.
-
 
 
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-name := "zuora-crediter"
+name := "zuora-creditor"
 description:= "This project contains a set of services and Lambda functions which find negative invoices and converts " +
   "them into a credit balance on the user's account, so that the amount is discounted off their next positive bill"
 version       := "0.0.1"
@@ -30,11 +30,11 @@ scalaxbDispatchVersion in (Compile, scalaxb) := dispatchV
 scalaxbPackageName in (Compile, scalaxb) := "com.gu.zuora.soap"
 scalaxbAsync in (Compile, scalaxb) := false
 
-assemblyJarName := "zuora-crediter.jar"
+assemblyJarName := "zuora-creditor.jar"
 riffRaffPackageType := assembly.value
 riffRaffUploadArtifactBucket := Option("riffraff-artifact")
 riffRaffUploadManifestBucket := Option("riffraff-builds")
-riffRaffManifestProjectName := "MemSub::Membership Admin::Zuora Crediter"
+riffRaffManifestProjectName := "MemSub::Membership Admin::Zuora Creditor"
 
 addCommandAlias("dist", ";riffRaffArtifact")
 

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -10,9 +10,10 @@ Parameters:
     Default: CODE
 
 Resources:
-  ZuoraCrediterRole:
+  ZuoraCreditorRole:
     Type: AWS::IAM::Role
     Properties:
+      RoleName: !Sub zuora-creditor-${Stage}
       AssumeRolePolicyDocument:
         Statement:
           - Effect: Allow
@@ -36,10 +37,10 @@ Resources:
   LambdaKMSKey:
     Type: AWS::KMS::Key
     Properties:
-      Description: !Sub Used by the zuora-crediter-${Stage} lambda to encrypt and decrypt its environment variables
+      Description: !Sub Used by the zuora-creditor-${Stage} lambda to encrypt and decrypt its environment variables
       KeyPolicy:
         Version: '2012-10-17'
-        Id: !Sub key-policy-zuora-crediter-${Stage}
+        Id: !Sub key-policy-zuora-creditor-${Stage}
         Statement:
         - Sid: Enable IAM User Permissions
           Effect: Allow
@@ -68,7 +69,7 @@ Resources:
           Principal:
             AWS:
               Fn::GetAtt:
-              - ZuoraCrediterRole
+              - ZuoraCreditorRole
               - Arn
           Action:
           - kms:Encrypt
@@ -81,22 +82,22 @@ Resources:
   LambdaKMSKeyAlias:
     Type: AWS::KMS::Alias
     Properties:
-      AliasName: !Sub alias/zuora-crediter-kms
+      AliasName: !Sub alias/zuora-creditor-kms-${Stage}
       TargetKeyId: !Ref LambdaKMSKey
     DependsOn: LambdaKMSKey
 
   Lambda:
     Type: AWS::Lambda::Function
     Properties:
-      FunctionName: !Sub zuora-crediter-${Stage}
+      FunctionName: !Sub zuora-creditor-${Stage}
       Code:
         S3Bucket: subscriptions-dist
         S3Key:
-          !Sub subscriptions/${Stage}/zuora-crediter/zuora-crediter.jar
+          !Sub subscriptions/${Stage}/zuora-creditor/zuora-creditor.jar
       Description: This Lambda finds negative invoices and converts them to be a credit on the customer's account so that the amount is deducted off their next positive bill.
-      Handler: com.gu.zuora.crediter.Lambda::handleRequest
+      Handler: com.gu.zuora.creditor.Lambda::handleRequest
       MemorySize: 512
-      Role: !GetAtt ZuoraCrediterRole.Arn
+      Role: !GetAtt ZuoraCreditorRole.Arn
       Runtime: java8
       Timeout: 60
       KmsKeyArn:

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -3,11 +3,11 @@ stacks:
 regions:
 - eu-west-1
 deployments:
-  zuora-crediter:
+  zuora-creditor:
     type: aws-lambda
     parameters:
-      fileName: zuora-crediter.jar
+      fileName: zuora-creditor.jar
       bucket: subscriptions-dist
       prefixStack: false
       functionNames:
-      - zuora-crediter-
+      - zuora-creditor-

--- a/src/main/scala/com/gu/zuora/creditor/CreditTransferService.scala
+++ b/src/main/scala/com/gu/zuora/creditor/CreditTransferService.scala
@@ -1,7 +1,7 @@
-package com.gu.zuora.crediter
+package com.gu.zuora.creditor
 
-import com.gu.zuora.crediter.Models.{CreateCreditBalanceAdjustmentCommand, ExportFile, NegativeInvoiceFileLine, NegativeInvoiceToTransfer}
-import com.gu.zuora.crediter.Types.{CreditBalanceAdjustmentIDs, ErrorMessage, ExportId, NegativeInvoiceReport}
+import com.gu.zuora.creditor.Models.{CreateCreditBalanceAdjustmentCommand, ExportFile, NegativeInvoiceFileLine, NegativeInvoiceToTransfer}
+import com.gu.zuora.creditor.Types.{CreditBalanceAdjustmentIDs, ErrorMessage, ExportId, NegativeInvoiceReport}
 import com.gu.zuora.soap.CreditBalanceAdjustment
 
 import scala.math.BigDecimal.RoundingMode.UP

--- a/src/main/scala/com/gu/zuora/creditor/Lambda.scala
+++ b/src/main/scala/com/gu/zuora/creditor/Lambda.scala
@@ -1,8 +1,8 @@
-package com.gu.zuora.crediter
+package com.gu.zuora.creditor
 
 import com.amazonaws.services.lambda.runtime.{Context, RequestHandler}
-import com.gu.zuora.crediter.Types.KeyValue
-import com.gu.zuora.crediter.holidaysuspension.{CreateHolidaySuspensionCredit, GetNegativeHolidaySuspensionInvoices}
+import com.gu.zuora.creditor.Types.KeyValue
+import com.gu.zuora.creditor.holidaysuspension.{CreateHolidaySuspensionCredit, GetNegativeHolidaySuspensionInvoices}
 
 import scala.collection.JavaConverters._
 
@@ -28,9 +28,9 @@ class Lambda extends RequestHandler[KeyValue, KeyValue] with Logging {
       }
       (maybeExportId getOrElse Map("nothingMoreToDo" -> true.toString)).asJava
     } else if (shouldCreditInvoices) {
-      val invoiceCrediter = new CreditTransferService(CreateHolidaySuspensionCredit)
+      val invoiceCreditor = new CreditTransferService(CreateHolidaySuspensionCredit)
       val exportId = event.get("creditInvoicesFromExport")
-      Map("numberOfInvoicesCredited" -> invoiceCrediter.processExportFile(exportId).toString).asJava
+      Map("numberOfInvoicesCredited" -> invoiceCreditor.processExportFile(exportId).toString).asJava
     } else {
       logger.error(s"Lambda called with incorrect input data: $event")
       Map("nothingToDo" -> true.toString).asJava

--- a/src/main/scala/com/gu/zuora/creditor/Logging.scala
+++ b/src/main/scala/com/gu/zuora/creditor/Logging.scala
@@ -1,4 +1,4 @@
-package com.gu.zuora.crediter
+package com.gu.zuora.creditor
 
 import org.apache.log4j.Logger
 

--- a/src/main/scala/com/gu/zuora/creditor/Models.scala
+++ b/src/main/scala/com/gu/zuora/creditor/Models.scala
@@ -1,7 +1,7 @@
-package com.gu.zuora.crediter
+package com.gu.zuora.creditor
 
-import com.gu.zuora.crediter.Models.NegativeInvoiceFileLine
-import com.gu.zuora.crediter.Types.{RawCSVText, SerialisedJson, ZOQLQueryFragment}
+import com.gu.zuora.creditor.Models.NegativeInvoiceFileLine
+import com.gu.zuora.creditor.Types.{RawCSVText, SerialisedJson, ZOQLQueryFragment}
 import com.gu.zuora.soap.CreditBalanceAdjustment
 import purecsv.unsafe
 import purecsv.unsafe.CSVReader

--- a/src/main/scala/com/gu/zuora/creditor/Types.scala
+++ b/src/main/scala/com/gu/zuora/creditor/Types.scala
@@ -1,8 +1,8 @@
-package com.gu.zuora.crediter
+package com.gu.zuora.creditor
 
 import java.util
 
-import com.gu.zuora.crediter.Models.{ExportFile, NegativeInvoiceFileLine}
+import com.gu.zuora.creditor.Models.{ExportFile, NegativeInvoiceFileLine}
 
 object Types {
   type ErrorMessage = String

--- a/src/main/scala/com/gu/zuora/creditor/ZuoraAPIClients.scala
+++ b/src/main/scala/com/gu/zuora/creditor/ZuoraAPIClients.scala
@@ -1,4 +1,4 @@
-package com.gu.zuora.crediter
+package com.gu.zuora.creditor
 
 import java.lang.System.getenv
 import java.net.URI
@@ -8,7 +8,7 @@ import java.nio.charset.Charset
 import com.amazonaws.services.kms.AWSKMSClientBuilder
 import com.amazonaws.services.kms.model.DecryptRequest
 import com.amazonaws.util.Base64
-import com.gu.zuora.crediter.Types.{RawCSVText, ZuoraSoapClientError, SerialisedJson}
+import com.gu.zuora.creditor.Types.{RawCSVText, ZuoraSoapClientError, SerialisedJson}
 import com.gu.zuora.soap.{CallOptions, Create, CreateResponse, SessionHeader, Soap, ZObjectable}
 
 import scala.reflect.internal.util.StringOps

--- a/src/main/scala/com/gu/zuora/creditor/ZuoraExportDownloadService.scala
+++ b/src/main/scala/com/gu/zuora/creditor/ZuoraExportDownloadService.scala
@@ -1,6 +1,6 @@
-package com.gu.zuora.crediter
+package com.gu.zuora.creditor
 
-import com.gu.zuora.crediter.Types.{ExportId, FileId, RawCSVText, SerialisedJson}
+import com.gu.zuora.creditor.Types.{ExportId, FileId, RawCSVText, SerialisedJson}
 import play.api.libs.json.Json.parse
 
 import scala.util.Try

--- a/src/main/scala/com/gu/zuora/creditor/ZuoraExportGenerator.scala
+++ b/src/main/scala/com/gu/zuora/creditor/ZuoraExportGenerator.scala
@@ -1,7 +1,7 @@
-package com.gu.zuora.crediter
+package com.gu.zuora.creditor
 
-import com.gu.zuora.crediter.Models.ExportCommand
-import com.gu.zuora.crediter.Types.{ExportId, SerialisedJson}
+import com.gu.zuora.creditor.Models.ExportCommand
+import com.gu.zuora.creditor.Types.{ExportId, SerialisedJson}
 import play.api.libs.json.Json.parse
 
 import scala.util.Try

--- a/src/main/scala/com/gu/zuora/creditor/holidaysuspension/CreateHolidaySuspensionCredit.scala
+++ b/src/main/scala/com/gu/zuora/creditor/holidaysuspension/CreateHolidaySuspensionCredit.scala
@@ -1,6 +1,6 @@
-package com.gu.zuora.crediter.holidaysuspension
+package com.gu.zuora.creditor.holidaysuspension
 
-import com.gu.zuora.crediter.Models.{CreateCreditBalanceAdjustmentCommand, NegativeInvoiceToTransfer}
+import com.gu.zuora.creditor.Models.{CreateCreditBalanceAdjustmentCommand, NegativeInvoiceToTransfer}
 import com.gu.zuora.soap.CreditBalanceAdjustment
 
 object CreateHolidaySuspensionCredit extends CreateCreditBalanceAdjustmentCommand {

--- a/src/main/scala/com/gu/zuora/creditor/holidaysuspension/GetNegativeHolidaySuspensionInvoices.scala
+++ b/src/main/scala/com/gu/zuora/creditor/holidaysuspension/GetNegativeHolidaySuspensionInvoices.scala
@@ -1,10 +1,10 @@
-package com.gu.zuora.crediter.holidaysuspension
+package com.gu.zuora.creditor.holidaysuspension
 import java.time.LocalDateTime.now
 import java.time.format.DateTimeFormatter.ISO_DATE_TIME
 
-import com.gu.zuora.crediter.Models.ExportCommand
-import com.gu.zuora.crediter.Models.NegativeInvoiceFileLine.selectForZOQL
-import com.gu.zuora.crediter.Types.SerialisedJson
+import com.gu.zuora.creditor.Models.ExportCommand
+import com.gu.zuora.creditor.Models.NegativeInvoiceFileLine.selectForZOQL
+import com.gu.zuora.creditor.Types.SerialisedJson
 import play.api.libs.json.Json
 
 case object GetNegativeHolidaySuspensionInvoices extends ExportCommand {

--- a/src/main/scala/com/gu/zuora/creditor/holidaysuspension/Main.scala
+++ b/src/main/scala/com/gu/zuora/creditor/holidaysuspension/Main.scala
@@ -1,6 +1,6 @@
-package com.gu.zuora.crediter.holidaysuspension
+package com.gu.zuora.creditor.holidaysuspension
 
-import com.gu.zuora.crediter.Lambda
+import com.gu.zuora.creditor.Lambda
 
 import scala.collection.JavaConverters._
 

--- a/src/test/scala/com/gu/zuora/creditor/CreditTransferServiceTest.scala
+++ b/src/test/scala/com/gu/zuora/creditor/CreditTransferServiceTest.scala
@@ -1,11 +1,11 @@
-package com.gu.zuora.crediter
+package com.gu.zuora.creditor
 
 import java.util.concurrent.atomic.AtomicInteger
 
-import com.gu.zuora.crediter.ModelReaders._
-import com.gu.zuora.crediter.Models.{CreateCreditBalanceAdjustmentCommand, ExportFile, NegativeInvoiceFileLine, NegativeInvoiceToTransfer}
-import com.gu.zuora.crediter.TestSoapClient.{getSuccessfulCreateResponse, getUnsuccessfulCreateResponseForHeadSource}
-import com.gu.zuora.crediter.Types.{CreditBalanceAdjustmentIDs, ZuoraSoapClientError}
+import com.gu.zuora.creditor.ModelReaders._
+import com.gu.zuora.creditor.Models.{CreateCreditBalanceAdjustmentCommand, ExportFile, NegativeInvoiceFileLine, NegativeInvoiceToTransfer}
+import com.gu.zuora.creditor.TestSoapClient.{getSuccessfulCreateResponse, getUnsuccessfulCreateResponseForHeadSource}
+import com.gu.zuora.creditor.Types.{CreditBalanceAdjustmentIDs, ZuoraSoapClientError}
 import com.gu.zuora.soap.{CreateResponse, CreditBalanceAdjustment, SaveResult, ZObjectable}
 import org.scalatest.FlatSpec
 

--- a/src/test/scala/com/gu/zuora/creditor/TestZuoraAPIClients.scala
+++ b/src/test/scala/com/gu/zuora/creditor/TestZuoraAPIClients.scala
@@ -1,8 +1,8 @@
-package com.gu.zuora.crediter
+package com.gu.zuora.creditor
 
 import java.util.concurrent.atomic.AtomicInteger
 
-import com.gu.zuora.crediter.Types.{RawCSVText, SerialisedJson, ZuoraSoapClientError}
+import com.gu.zuora.creditor.Types.{RawCSVText, SerialisedJson, ZuoraSoapClientError}
 import com.gu.zuora.soap.{CreateResponse, Error, SaveResult, ZObjectable}
 
 class TestSoapClient extends ZuoraSoapClient {

--- a/src/test/scala/com/gu/zuora/creditor/ZuoraExportDownloadServiceTest.scala
+++ b/src/test/scala/com/gu/zuora/creditor/ZuoraExportDownloadServiceTest.scala
@@ -1,6 +1,6 @@
-package com.gu.zuora.crediter
+package com.gu.zuora.creditor
 
-import com.gu.zuora.crediter.Types.{RawCSVText, SerialisedJson}
+import com.gu.zuora.creditor.Types.{RawCSVText, SerialisedJson}
 import org.scalatest.FlatSpec
 
 class ZuoraExportDownloadServiceTest extends FlatSpec {

--- a/src/test/scala/com/gu/zuora/creditor/ZuoraExportGeneratorTest.scala
+++ b/src/test/scala/com/gu/zuora/creditor/ZuoraExportGeneratorTest.scala
@@ -1,7 +1,7 @@
-package com.gu.zuora.crediter
+package com.gu.zuora.creditor
 
-import com.gu.zuora.crediter.Models.ExportCommand
-import com.gu.zuora.crediter.Types.SerialisedJson
+import com.gu.zuora.creditor.Models.ExportCommand
+import com.gu.zuora.creditor.Types.SerialisedJson
 import org.scalatest.FlatSpec
 
 class ZuoraExportGeneratorTest extends FlatSpec {


### PR DESCRIPTION
- Renamed 'crediter' to 'creditor' wherever I could find it. It's now meant to be understood as as definition (2) in http://www.dictionary.com/browse/creditor. :slightly_frowning_face: 
I'll rename the git repo asap. Then update TeamCity and RiffRaff.
- Also made a couple of small tweaks to cloudformation.yaml to properly allow for multi-stack use, similar to: https://github.com/guardian/zuora-auto-cancel/pull/8

cc @jacobwinch 